### PR TITLE
Message format for RadarDetection

### DIFF
--- a/msg/RadarDetection.msg
+++ b/msg/RadarDetection.msg
@@ -7,5 +7,5 @@
                                             # NB: The z component of these fields is ignored for 2D tracking.
 geometry_msgs/Point position                # x, y, z coordinates of the centroid of the object being tracked.
 geometry_msgs/Vector3 velocity              # The velocity of the object in each spacial dimension.
-geometry_msgs/Vector3 size                  # The RCS or average deviation (m) in the x, y, z, dimensions
+geometry_msgs/Vector3 size                  # The average deviation (m) in the x, y, z, dimensions
                                             #   between the center of the object and the data points which it is derived from.

--- a/msg/RadarDetection.msg
+++ b/msg/RadarDetection.msg
@@ -4,8 +4,7 @@
 # Radar detections are the discrete clusterings of points
 # Detections which are filtered into moving objects are referred to as Tracks
 
-                                            # NB: The z component of these fields is ignored for 2D tracking.
+                                            # Note: The z component of these fields is ignored for 2D tracking.
 geometry_msgs/Point position                # x, y, z coordinates of the centroid of the object being tracked.
 geometry_msgs/Vector3 velocity              # The velocity of the object in each spatial dimension.
-geometry_msgs/Vector3 size                  # The average deviation (m) in the x, y, z, dimensions
-                                            #   between the center of the object and the data points which it is derived from.
+geometry_msgs/Vector3 size                  # The object size (m) in the x, y, z, dimensions

--- a/msg/RadarDetection.msg
+++ b/msg/RadarDetection.msg
@@ -6,6 +6,6 @@
 
                                             # NB: The z component of these fields is ignored for 2D tracking.
 geometry_msgs/Point position                # x, y, z coordinates of the centroid of the object being tracked.
-geometry_msgs/Vector3 velocity              # The velocity of the object in each spacial dimension.
+geometry_msgs/Vector3 velocity              # The velocity of the object in each spatial dimension.
 geometry_msgs/Vector3 size                  # The average deviation (m) in the x, y, z, dimensions
                                             #   between the center of the object and the data points which it is derived from.

--- a/msg/RadarDetection.msg
+++ b/msg/RadarDetection.msg
@@ -1,0 +1,11 @@
+# All variables below are relative to the radar's frame of reference.
+# This message is not meant to be used alone but as part of a stamped or array message.
+
+# Radar detections are the discrete clusterings of points
+# Detections which are filtered into moving objects are referred to as Tracks
+
+                                            # NB: The z component of these fields is ignored for 2D tracking.
+geometry_msgs/Point position                # x, y, z coordinates of the centroid of the object being tracked.
+geometry_msgs/Vector3 velocity              # The velocity of the object in each spacial dimension.
+geometry_msgs/Vector3 size                  # The RCS or average deviation (m) in the x, y, z, dimensions
+                                            #   between the center of the object and the data points which it is derived from.

--- a/msg/RadarDetections.msg
+++ b/msg/RadarDetections.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+
+radar_msgs/RadarDetection[] detections


### PR DESCRIPTION
The proposed message format for RadarDetection.

Prior to proposing this format, research was done into the radar data message formats that exist out in the wild. The details of this analysis can be found here: https://github.com/radarAaron/radar_msgs/blob/master/ROS%20Message%20format%20comparison.xlsx


## Summary
Four drivers appear to output something akin to a detection.

**Position in 3D space**
Each driver outputs position, however each uses a different format. Two use polar coordinates and two Cartesian. Only 2 of the 4 drivers contained any sort of uncertainty information.

Used position formats:
* geometry_msgs/Point position (No uncertainty)
* geometry_msgs/PoseWithCovariance   (Covariance)
* range, azimuth, elevation (no uncertainty)
* distance, angle (uncertainty expressed as deviations)

**Velocity**
Each driver outputs different velocity information, some containing directional information and some do not. Only one outputs any sort of uncertainty information. These could be reconciled into a Vector3 type with any velocity components which are not supported by the specific driver, being set to zero. The question about how to handle uncertainty remains.

Used velocity formats:
* geometry_msgs/Vector3 velocity (no uncertainty)
* TwistWithCovariance (covariance)
* float64 speed along x axis (no uncertainty)
* float32 velocity (no uncertainty)

**Size/Shape**
Only one driver outputs size information. This is outputted as RCS (radar cross section)

**Acceleration**
No driver exposes acceleration

**Additional Fields**
Drivers also output the following fields: Amplitude, dynamic property, class_type

**Conclusion**
* There is no consensus on how the position of objects is reported, or even what coordinates system to use. The call was made to report this using Cartesian coordinates.

* Velocity could be reconciled into a Vector3 type with the velocity components not supported by specific drivers being set to zero.

* There is no consensus about how the size of a shape is reported, with the only option being RCS. The call was made to represent 'size' using an ovaloid shape based on the distribution of points in 3D space.

* It is unclear how uncertainty should be presented.

## Notes
Object detentions are based on usually based on a point cloud. The point cloud shape is somewhat object specific and does not necessarily cover the full size of the object (eg. points tend to concentrate towards the center). The 'size' format chosen here is based on the distribution of points in 3D space. An **alternative** approach for expressing the size would be as a covariance matrix.

## Questions
* Should size be expressed as 'size' or as a covariance matrix?
* Is expressing the uncertainty of the velocity component important?