### PR TITLE
Adapt RadarReturn and RadarScan

### DIFF
--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -7,4 +7,4 @@ float32 azimuth                          # Angle (in radians) in the azimuth pla
 float32 elevation                        # Angle (in radians) in the elevation plane between the sensor and the detected return.
                                          # Negative angles are below the sensor. For 2D radar, this will be 0.
 float32 doppler_velocity                 # The doppler speed (m/s) of the return.
-float32 amplitude                        # The amplitude of the return (dB).
+float32 amplitude                        # The radar cross section of the return (RCS linear/m^2).

--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -2,6 +2,7 @@
 # This message is not meant to be used alone but as part of a stamped or array message.
 
 float32 range                            # Distance (m) from the sensor to the detected return.
+# The angles order of the angles are elevation-over-azimuth
 float32 azimuth                          # Angle (in radians) in the azimuth plane between the sensor and the detected return.
                                          # Positive angles are anticlockwise from the sensor and negative angles clockwise from the sensor as per REP-0103.
 float32 elevation                        # Angle (in radians) in the elevation plane between the sensor and the detected return.

--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -1,6 +1,8 @@
 # All variables below are relative to the radar's frame of reference.
 # This message is not meant to be used alone but as part of a stamped or array message.
 
+builtin_interfaces/Duration stamp_offset # Offset to the stamp in the RadarScan message.
+                                         # If the offset is unknown it should be set to 0.
 float32 range                            # Distance (m) from the sensor to the detected return.
 # The angles order of the angles are elevation-over-azimuth
 float32 azimuth                          # Angle (in radians) in the azimuth plane between the sensor and the detected return.

--- a/msg/RadarScan.msg
+++ b/msg/RadarScan.msg
@@ -1,3 +1,4 @@
-std_msgs/Header header
+std_msgs/Header header                        # timestamp in the header is the acquisition time of
+                                              # the first beam in the scan.
 
 radar_msgs/RadarReturn[] returns

--- a/msg/RadarScan.msg
+++ b/msg/RadarScan.msg
@@ -1,4 +1,6 @@
 std_msgs/Header header                        # timestamp in the header is the acquisition time of
                                               # the first beam in the scan.
 
+radar_msgs/SensorProperties sensor_properties
+
 radar_msgs/RadarReturn[] returns

--- a/msg/SensorProperties.msg
+++ b/msg/SensorProperties.msg
@@ -1,0 +1,7 @@
+string serial                  # Manufacturer specific serial number 
+string sensor_type             # Manufacturer specific name, should be
+                               # used as "<manufacturer>:<product_name>" 
+
+float32 phase_center           # The focal point of the radar waves (radius)
+float32[3] position_resolution # 3 dB resolution in order (radial, azimuth, elevation)
+float32 velocity_resolution    # 3 dB resolution (radial resolution)


### PR DESCRIPTION
This PR proposes several changed to the `RadarReturn` and `RadarScan` messages.

## Summary

### Time stamp

The current message for a `RadarScan` just stores one time stamp for all returns.
And this time stamp is not clearly defined.

**Proposed change**
- Add the field `stamp_offset` to `RadarReturn`, which will be used relatively to the time stamp of the time stamp in the field `header` of `RadarScan`.
- Define the time stamp of the field `header` of `RadarScan` to be of the first return.

### Usage of the spherical angles

The current description for the `azimuth` and `elevation` angles doesn't directly specify the order of these angles.
From the comment for `elevation` "For 2D radar, this will be 0." the order can be deducted, but it could be clearer.

**Proposed change**
- Add the description that the angles are supposed to be used as "elevation-over-azimuth"

### Missing Measurement characteristics

While for LiDAR sensors the measured returns are typically treated as points, this behavior is problematic for radar sensors.

**Proposed change**
- Add the field `sensor_properties` to `RadarScan`
- Add the message`SensorProperties` to group the information about the device used for the measurement.

### Missing definition of amplitude

The description for the field `amplitude` is missing the relative information of the measurement.

**Proposed change**
- Define the field as RCS linear/m^2.
  (Please note that this also changes the logarithmic value to a linear one.)