### PR TITLE
RadarReturn: clarify order of angles

### DIFF
--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -2,6 +2,7 @@
 # This message is not meant to be used alone but as part of a stamped or array message.
 
 float32 range                            # Distance (m) from the sensor to the detected return.
+                                         # The angles order of the angles are elevation-over-azimuth
 float32 azimuth                          # Angle (in radians) in the azimuth plane between the sensor and the detected return.
                                          # Positive angles are anticlockwise from the sensor and negative angles clockwise from the sensor as per REP-0103.
 float32 elevation                        # Angle (in radians) in the elevation plane between the sensor and the detected return.


### PR DESCRIPTION
The current description for the `azimuth` and `elevation` angles doesn't directly specify the order of these angles.
From the comment for `elevation` "For 2D radar, this will be 0." the order can be deducted, but it could be clearer.

**Proposed change**
- Add the description that the angles are supposed to be used as "elevation-over-azimuth"
