### PR TITLE
Improve timestamp granularity of different measurements within a scan

### DIFF
--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -1,6 +1,8 @@
 # All variables below are relative to the radar's frame of reference.
 # This message is not meant to be used alone but as part of a stamped or array message.
 
+builtin_interfaces/Duration stamp_offset # Offset to the stamp in the RadarScan message.
+                                         # If the offset is unknown it should be set to 0.
 float32 range                            # Distance (m) from the sensor to the detected return.
 float32 azimuth                          # Angle (in radians) in the azimuth plane between the sensor and the detected return.
                                          # Positive angles are anticlockwise from the sensor and negative angles clockwise from the sensor as per REP-0103.

--- a/msg/RadarScan.msg
+++ b/msg/RadarScan.msg
@@ -1,3 +1,4 @@
-std_msgs/Header header
+std_msgs/Header header                        # timestamp in the header is the acquisition time of
+                                              # the first beam in the scan.
 
 radar_msgs/RadarReturn[] returns


### PR DESCRIPTION
The current message for a `RadarScan` just stores one time stamp for all returns.
And this time stamp is not clearly defined.

**Proposed change**
- Add the field `stamp_offset` to `RadarReturn`, which will be used relatively to the time stamp of the time stamp in the field `header` of `RadarScan`.
- Define the time stamp of the field `header` of `RadarScan` to be of the first return.