### PR TITLE
Change unit of amplitude

### DIFF
--- a/msg/RadarReturn.msg
+++ b/msg/RadarReturn.msg
@@ -7,4 +7,4 @@ float32 azimuth                          # Angle (in radians) in the azimuth pla
 float32 elevation                        # Angle (in radians) in the elevation plane between the sensor and the detected return.
                                          # Negative angles are below the sensor. For 2D radar, this will be 0.
 float32 doppler_velocity                 # The doppler speed (m/s) of the return.
-float32 amplitude                        # The amplitude of the return (dB).
+float32 rcs                              # The radar cross section of the return (RCS dBm^2).


### PR DESCRIPTION
The description for the field `amplitude` is missing the relative information of the measurement.

**Proposed change**
- Define the field as RCS linear/m^2.
  (Please note that this also changes the logarithmic value to a linear one.)