### PR TITLE
Add sensor characteristics to RadarScan

### DIFF
--- a/msg/RadarScan.msg
+++ b/msg/RadarScan.msg
@@ -1,3 +1,5 @@
 std_msgs/Header header
 
+radar_msgs/SensorProperties sensor_properties
+
 radar_msgs/RadarReturn[] returns

--- a/msg/SensorProperties.msg
+++ b/msg/SensorProperties.msg
@@ -1,0 +1,7 @@
+string serial_no               # Manufacturer specific serial number
+string sensor_type             # Manufacturer specific name, should be
+                               # used as "<manufacturer>:<product_name>" 
+
+float32 phase_center           # The focal point of the radar waves (radius)
+float32[3] position_resolution # 3 dB resolution in order (radial, azimuth, elevation)
+float32 velocity_resolution    # 3 dB resolution (radial resolution)


### PR DESCRIPTION
While for LiDAR sensors the measured returns are typically treated as points, this behavior is problematic for radar sensors.

**Proposed change**
- Add the field `sensor_properties` to `RadarScan`
- Add the message`SensorProperties` to group the information about the device used for the measurement.